### PR TITLE
fix: admin clicking an event in a on the event dashboard list opening…

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -187,7 +187,7 @@ export default function AdminEventsPage() {
                           )}
                           onClick={() => {
                             if (canModify) {
-                              handleAction("view", event.id, event.eventStatus);
+                              handleAction("edit", event.id, event.eventStatus);
                             }
                           }}
                         >


### PR DESCRIPTION
… the event details page instead of the edit details page